### PR TITLE
Hide the print button if the browser doesn't support window.print

### DIFF
--- a/public/score_form.php
+++ b/public/score_form.php
@@ -50,10 +50,22 @@ Your score: <span class="score"><?php echo $exam->Score(); ?> / <?php echo $exam
 <label for="submit_results">Submit these results for points</label>
 <input type="checkbox" checked="checked" name="submit_results" id="submit_results" value="1" />
 <div class="results-buttons">
-    <input type="button" onclick="window.print();" value="Print" name="print">
+    <input type="button" onclick="window.print();" value="Print" name="print" id="printButton">
     <input type="submit" name="submit" value="Done">
 </div>
 </form>
+
+<script>
+	function checkForPrint() {
+		'use strict';
+		if (!window.print) {
+			var printButton = document.getElementById('printButton');
+			printButton.style.display = 'none';
+		}
+	}
+	checkForPrint();
+</script>
+
 <?php
 
 include("_footer.php");


### PR DESCRIPTION
This is a hack to reduce the times that a user might see the Print button even when they can't use it, e.g. on the Bettercare Cordova app we're working on.

Ultimately we need a more robust solution for saving quiz results.